### PR TITLE
Fix generated file names

### DIFF
--- a/lib/rails/generators/invoicing/ledger_item/ledger_item_generator.rb
+++ b/lib/rails/generators/invoicing/ledger_item/ledger_item_generator.rb
@@ -6,7 +6,7 @@ module Invoicing
       source_root File.expand_path("../templates", __FILE__)
 
       def copy_migrations
-        migration_template "migration.rb", "db/migrate/invoicing_ledger_items.rb"
+        migration_template "migration.rb", "db/migrate/create_invoicing_ledger_items.rb"
       end
 
       def copy_models

--- a/lib/rails/generators/invoicing/line_item/line_item_generator.rb
+++ b/lib/rails/generators/invoicing/line_item/line_item_generator.rb
@@ -6,7 +6,7 @@ module Invoicing
       source_root File.expand_path("../templates", __FILE__)
 
       def copy_migrations
-        migration_template "migration.rb", "db/migrate/invoicing_line_items.rb"
+        migration_template "migration.rb", "db/migrate/create_invoicing_line_items.rb"
       end
 
       def copy_models

--- a/lib/rails/generators/invoicing/tax_rate/tax_rate_generator.rb
+++ b/lib/rails/generators/invoicing/tax_rate/tax_rate_generator.rb
@@ -6,7 +6,7 @@ module Invoicing
       source_root File.expand_path("../templates", __FILE__)
 
       def copy_migration_file
-        migration_template "migration.rb", "db/migrate/invoicing_tax_rates.rb"
+        migration_template "migration.rb", "db/migrate/create_invoicing_tax_rates.rb"
       end
 
       def copy_model

--- a/lib/rails/generators/invoicing/tax_rate/templates/migration.rb
+++ b/lib/rails/generators/invoicing/tax_rate/templates/migration.rb
@@ -1,4 +1,4 @@
-class CreateInvoicingTaxable < ActiveRecord::Migration
+class CreateInvoicingTaxRates < ActiveRecord::Migration
   def change
     create_table :invoicing_tax_rates do |t|
       t.string   :description

--- a/lib/rails/generators/invoicing/tax_rate/templates/model.rb
+++ b/lib/rails/generators/invoicing/tax_rate/templates/model.rb
@@ -1,3 +1,3 @@
-class TaxRate < ActiveRecord::Base
+class InvoicingTaxRate < ActiveRecord::Base
   acts_as_tax_rate
 end

--- a/test/invoicing_generator_test.rb
+++ b/test/invoicing_generator_test.rb
@@ -35,9 +35,9 @@ class InvoicingGeneratorTest < Rails::Generators::TestCase
 
       Dir.chdir(TMP_PATH) do
         # assert that models are created
-        assert_file "db/migrate/1_invoicing_ledger_items.rb"
-        assert_file "db/migrate/1_invoicing_line_items.rb"
-        assert_file "db/migrate/1_invoicing_tax_rates.rb"
+        assert_file "db/migrate/1_create_invoicing_ledger_items.rb"
+        assert_file "db/migrate/1_create_invoicing_line_items.rb"
+        assert_file "db/migrate/1_create_invoicing_tax_rates.rb"
       end
     end
   end


### PR DESCRIPTION
This fixes `uninitialized constant InvoicingTaxRates` when running 
migrations generated by the Invoicing generator. The migrations were 
not named following rails convention of filename matching with the 
classname.
