### PR TITLE
Prefix sorting clause with table name

### DIFF
--- a/lib/invoicing/ledger_item.rb
+++ b/lib/invoicing/ledger_item.rb
@@ -376,11 +376,12 @@ module Invoicing
       }
 
       scope :sorted, lambda { |column|
+        table = ledger_item_class_info.method(quoted_table_name).to_s
         column = ledger_item_class_info.method(column).to_s
         if column_names.include?(column)
-          order("#{connection.quote_column_name(column)}, #{connection.quote_column_name(primary_key)}")
+          order("#{table}.#{connection.quote_column_name(column)}, #{table}.#{connection.quote_column_name(primary_key)}")
         else
-          order(connection.quote_column_name(primary_key))
+          order("#{table}.#{connection.quote_column_name(primary_key)}")
         end
       }
 

--- a/lib/invoicing/line_item.rb
+++ b/lib/invoicing/line_item.rb
@@ -171,11 +171,12 @@ module Invoicing
       }
 
       scope :sorted, lambda { |column|
+        table = line_item_class_info.method(quoted_table_name).to_s
         column = line_item_class_info.method(column).to_s
         if column_names.include?(column)
-          order("#{connection.quote_column_name(column)}, #{connection.quote_column_name(primary_key)}")
+          order("#{table}.#{connection.quote_column_name(column)}, #{table}.#{connection.quote_column_name(primary_key)}")
         else
-          order(connection.quote_column_name(primary_key))
+          order("#{table}.#{connection.quote_column_name(primary_key)}")
         end
       }
     end


### PR DESCRIPTION
Prevents error if a association has been included/joined, and that association has similar column names to InvoicingLineItem / InvoicingLedgerItem. (just joining any model which has an id attribute will actually cause an error).
