### PR TITLE
Added Gemfile, fixed warnings

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,2 @@
+source 'https://rubygems.org'
+gem 'jekyll'

--- a/_config.yml
+++ b/_config.yml
@@ -4,6 +4,6 @@ description: Ruby Invoicing Framework
 
 permalink: /:year/:month/:day/:title/
 paginate: 10
-pygments: true
+highlighter: true
 
 exclude: ['README.md', 'Gemfile.lock', 'Gemfile', 'Rakefile']

--- a/feed.xml
+++ b/feed.xml
@@ -1,5 +1,5 @@
 ---
-layout: none
+layout: null
 ---
 <?xml version="1.0" encoding="UTF-8"?>
 <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">


### PR DESCRIPTION
Added Gemfile, fixed build warnings:

```
Deprecation: The 'pygments' configuration option has been renamed to 'highlighter'. Please update your config file accordingly. The allowed values are 'rouge', 'pygments' or null.
Build Warning: Layout 'none' requested in feed.xml does not exist.
```
