### PR TITLE
Big decimal fix

### DIFF
--- a/lib/invoicing/currency_value.rb
+++ b/lib/invoicing/currency_value.rb
@@ -286,7 +286,7 @@ module Invoicing
 
         unless value
           raw_value = object.read_attribute(attr)
-          value = BigDecimal.new(raw_value.to_s) unless raw_value.nil?
+          value = BigDecimal(raw_value.to_s) unless raw_value.nil?
         end
         value
       end

--- a/lib/invoicing/currency_value.rb
+++ b/lib/invoicing/currency_value.rb
@@ -119,7 +119,7 @@ module Invoicing
 
     included do
       # Register callback if this is the first time acts_as_currency_value has been called
-      before_save :write_back_currency_values, :if => "currency_value_class_info.previous_info.nil?"
+      before_save :write_back_currency_values
     end
 
     # Format a numeric monetary value into a human-readable string, in the currency of the

--- a/lib/invoicing/time_dependent.rb
+++ b/lib/invoicing/time_dependent.rb
@@ -195,7 +195,7 @@ module Invoicing
         # Create replaced_by association if it doesn't exist yet
         replaced_by_id = time_dependent_class_info.method(:replaced_by_id)
         unless respond_to? :replaced_by
-          belongs_to :replaced_by, :class_name => self, :foreign_key => replaced_by_id
+          belongs_to :replaced_by, :class_name => self.to_s, :foreign_key => replaced_by_id
         end
 
         # Create value_at and value_now method aliases

--- a/lib/invoicing/time_dependent.rb
+++ b/lib/invoicing/time_dependent.rb
@@ -195,7 +195,7 @@ module Invoicing
         # Create replaced_by association if it doesn't exist yet
         replaced_by_id = time_dependent_class_info.method(:replaced_by_id)
         unless respond_to? :replaced_by
-          belongs_to :replaced_by, :class_name => self.to_s, :foreign_key => replaced_by_id
+          belongs_to :replaced_by, class_name: name, foreign_key: replaced_by_id
         end
 
         # Create value_at and value_now method aliases


### PR DESCRIPTION
Minor change, using new `BigDecimal()` calls per Ruby 2.6's deprecation warning.