### PR TITLE
Fix currency_value_class_info error

### DIFF
--- a/lib/invoicing/currency_value.rb
+++ b/lib/invoicing/currency_value.rb
@@ -119,7 +119,7 @@ module Invoicing
 
     included do
       # Register callback if this is the first time acts_as_currency_value has been called
-      before_save :write_back_currency_values, if: currency_value_class_info.previous_info.nil?
+      before_save :write_back_currency_values, if: -> { currency_value_class_info.previous_info.nil? }
     end
 
     # Format a numeric monetary value into a human-readable string, in the currency of the


### PR DESCRIPTION
Fixes #66

Originally the method was passed as a string to the if condition.
This is equivalent to passing the method itself rather than using
the result of the method call in the if condition.

When adding support for Rails 5, the string was replaced with the
method call which caused the bug. This has been replace with a lambda
which represents the method itself rather than the result of the method
being called.