### PR TITLE
TimeDependent belongs_to replaced_by association should be optional for rails5.2

### DIFF
--- a/lib/invoicing/time_dependent.rb
+++ b/lib/invoicing/time_dependent.rb
@@ -195,7 +195,7 @@ module Invoicing
         # Create replaced_by association if it doesn't exist yet
         replaced_by_id = time_dependent_class_info.method(:replaced_by_id)
         unless respond_to? :replaced_by
-          belongs_to :replaced_by, class_name: name, foreign_key: replaced_by_id
+          belongs_to :replaced_by, class_name: name, foreign_key: replaced_by_id, optional: true
         end
 
         # Create value_at and value_now method aliases


### PR DESCRIPTION
With the rails 5 update, belongs_to association are require by default.

When trying to upgrade a rails 4 to rails 5 app with invoicing, InvoicingTaxRate failed due to this issue.

I think this PR fix it.

